### PR TITLE
Fixed issue in MtdTaxYearValidation.

### DIFF
--- a/app/v1/controllers/requestParsers/validators/validations/MtdTaxYearValidation.scala
+++ b/app/v1/controllers/requestParsers/validators/validations/MtdTaxYearValidation.scala
@@ -26,6 +26,6 @@ object MtdTaxYearValidation {
 
     val desTaxYear = Integer.parseInt(DesTaxYear.fromMtd(taxYear).value)
 
-    if (desTaxYear >= minTaxYear || TaxYearValidation.validate(taxYear) != Nil) NoValidationErrors else List(RuleTaxYearNotSupportedError)
+    if (desTaxYear >= minTaxYear && TaxYearValidation.validate(taxYear) == Nil) NoValidationErrors else List(RuleTaxYearNotSupportedError)
   }
 }


### PR DESCRIPTION
Certain invalid tax years would fail the first validation condition, and then pass the second condition returning no errors. This issue has been resolved by making a minor change to the logic in the MtdTaxYearValidation file.