### PR TITLE
MTDSA-4269 - clean up model reads

### DIFF
--- a/app/v1/models/des/LossType.scala
+++ b/app/v1/models/des/LossType.scala
@@ -16,7 +16,9 @@
 
 package v1.models.des
 
+import cats.Show
 import play.api.libs.json._
+import utils.enums.Enums
 
 sealed trait LossType
 
@@ -24,10 +26,7 @@ object LossType {
   case object INCOME extends LossType
   case object CLASS4NICS extends LossType
 
-  implicit val reads: Reads[LossType] = implicitly[Reads[String]].collect(JsonValidationError("error.expected.lossType")){
-    case "income" => INCOME
-    case "class4nics" => CLASS4NICS
-  }
+  implicit val show : Show[LossType] = Show.show(_.toString.toLowerCase)
 
-  implicit val writes: Writes[LossType] = Writes[LossType](ts => JsString(ts.toString.toLowerCase()))
+  implicit val format : Format[LossType] = Enums.format[LossType]
 }

--- a/app/v1/models/des/ReliefClaimed.scala
+++ b/app/v1/models/des/ReliefClaimed.scala
@@ -17,6 +17,7 @@
 package v1.models.des
 
 import play.api.libs.json._
+import utils.enums.Enums
 import v1.models.domain.TypeOfClaim
 
 sealed trait ReliefClaimed {
@@ -41,14 +42,5 @@ object ReliefClaimed {
     override def toTypeOfClaim: TypeOfClaim = TypeOfClaim.`carry-sideways-fhl`
   }
 
-  val parser: PartialFunction[String, ReliefClaimed] = {
-    case "CF" => `CF`
-    case "CSGI" => `CSGI`
-    case "CFCSGI" => `CFCSGI`
-    case "CSFHL" => `CSFHL`
-  }
-
-  implicit val reads: Reads[ReliefClaimed] = implicitly[Reads[String]].collect(JsonValidationError("error.expected.reliefClaimed"))(parser)
-
-  implicit val writes: Writes[ReliefClaimed] = Writes[ReliefClaimed](ts => JsString(ts.toString))
+  implicit val format: Format[ReliefClaimed] = Enums.format[ReliefClaimed]
 }

--- a/app/v1/models/domain/TypeOfClaim.scala
+++ b/app/v1/models/domain/TypeOfClaim.scala
@@ -16,42 +16,20 @@
 
 package v1.models.domain
 
-import play.api.libs.json.{JsString, JsonValidationError, Reads, Writes}
-import v1.models.des.ReliefClaimed
+import play.api.libs.json.Format
+import utils.enums.Enums
 
-sealed trait TypeOfClaim {
-  def toReliefClaimed: ReliefClaimed
-}
+sealed trait TypeOfClaim
 
 object TypeOfClaim {
 
+  case object `carry-forward` extends TypeOfClaim
 
-  case object `carry-forward` extends TypeOfClaim {
-    override def toReliefClaimed: ReliefClaimed = ReliefClaimed.`CF`
-  }
+  case object `carry-sideways` extends TypeOfClaim
 
-  case object `carry-sideways` extends TypeOfClaim {
-    override def toReliefClaimed: ReliefClaimed = ReliefClaimed.`CSGI`
-  }
+  case object `carry-forward-to-carry-sideways` extends TypeOfClaim
 
-  case object `carry-forward-to-carry-sideways` extends TypeOfClaim {
-    override def toReliefClaimed: ReliefClaimed = ReliefClaimed.`CFCSGI`
-  }
+  case object `carry-sideways-fhl` extends TypeOfClaim
 
-  case object `carry-sideways-fhl` extends TypeOfClaim {
-    override def toReliefClaimed: ReliefClaimed = ReliefClaimed.`CSFHL`
-  }
-
-
-  val parser: PartialFunction[String, TypeOfClaim] = {
-    case "carry-forward"    => `carry-forward`
-    case "carry-sideways"    => `carry-sideways`
-    case "carry-forward-to-carry-sideways" => `carry-forward-to-carry-sideways`
-    case "carry-sideways-fhl" => `carry-sideways-fhl`
-  }
-
-  implicit val reads: Reads[TypeOfClaim] = implicitly[Reads[String]].collect(JsonValidationError("error.expected.typeOfClaim"))(parser)
-
-  implicit val writes: Writes[TypeOfClaim] = Writes[TypeOfClaim](ts => JsString(ts.toString))
+  implicit val formats: Format[TypeOfClaim] = Enums.format[TypeOfClaim]
 }
-

--- a/app/v1/models/response/common/Messages.scala
+++ b/app/v1/models/response/common/Messages.scala
@@ -26,15 +26,11 @@ object Message {
   implicit val format: OFormat[Message] = Json.format[Message]
 }
 
-
-case class Messages(info: Option[Seq[Message]], warnings: Option[Seq[Message]], errors: Option[Seq[Message]]){
-  def hasMessages: Boolean = this match{
-    case Messages(None,None,None) => false
-    case _ => true
-  }
-}
+case class Messages(info: Option[Seq[Message]], warnings: Option[Seq[Message]], errors: Option[Seq[Message]])
 
 object Messages {
+  val empty = Messages(None, None, None)
+
   implicit val writes: OWrites[Messages] = Json.writes[Messages]
   implicit val reads: Reads[Messages] = (
     (__ \ "messages" \ "info").readNestedNullable[Seq[Message]].map {

--- a/app/v1/models/response/getCalculation/GetCalculationResponse.scala
+++ b/app/v1/models/response/getCalculation/GetCalculationResponse.scala
@@ -43,8 +43,8 @@ object GetCalculationResponse extends NestedJsonReads {
       JsPath.read[Metadata] and
         emptyIfNotPresent[IncomeTax](__ \ "calculation") and
         JsPath.readNullable[Messages].map {
-          case Some(messages) if messages.hasMessages => Some(messages)
-          case _                                      => None
+          case Some(Messages.empty) => None
+          case other => other
         } and
         emptyIfNotPresent[TaxableIncome](__ \ "calculation") and
         (__ \ "calculation" \ "endOfYearEstimate").readNestedNullable[EoyEstimate] and

--- a/app/v1/models/response/getCalculation/allowancesAndDeductions/detail/AllowancesAndDeductions.scala
+++ b/app/v1/models/response/getCalculation/allowancesAndDeductions/detail/AllowancesAndDeductions.scala
@@ -27,6 +27,8 @@ case class AllowancesAndDeductions(personalAllowance: Option[BigInt],
                                    lossesAppliedToGeneralIncome: Option[BigInt])
 
 object AllowancesAndDeductions extends NestedJsonReads{
+  val empty = AllowancesAndDeductions(None, None, None, None, None)
+
   implicit val writes: OWrites[AllowancesAndDeductions] = Json.writes[AllowancesAndDeductions]
 
   implicit val reads: Reads[AllowancesAndDeductions] = (

--- a/app/v1/models/response/getCalculation/allowancesAndDeductions/detail/CalculationDetail.scala
+++ b/app/v1/models/response/getCalculation/allowancesAndDeductions/detail/CalculationDetail.scala
@@ -23,16 +23,18 @@ case class CalculationDetail(allowancesAndDeductions: Option[AllowancesAndDeduct
                         reliefs: Option[Reliefs])
 
 object CalculationDetail {
+  val empty = CalculationDetail(None, None)
+
   implicit val writes: OWrites[CalculationDetail] = Json.writes[CalculationDetail]
 
   implicit val reads: Reads[CalculationDetail] = (
-    JsPath.readNullable[AllowancesAndDeductions].map(_.flatMap {
-      case AllowancesAndDeductions(None,None,None, None, None) => None
-      case x => Some(x)
-    }) and
-    JsPath.readNullable[Reliefs].map(_.flatMap {
-      case Reliefs(None) => None
-      case x => Some(x)
-    })
+    JsPath.readNullable[AllowancesAndDeductions].map {
+      case Some(AllowancesAndDeductions.empty) => None
+      case other => other
+    } and
+    JsPath.readNullable[Reliefs].map{
+      case Some(Reliefs.empty) => None
+      case other => other
+    }
   )(CalculationDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/allowancesAndDeductions/detail/Reliefs.scala
+++ b/app/v1/models/response/getCalculation/allowancesAndDeductions/detail/Reliefs.scala
@@ -22,6 +22,8 @@ import utils.NestedJsonReads
 case class Reliefs (residentialFinanceCosts: Option[ResidentialFinanceCosts])
 
 object Reliefs extends NestedJsonReads{
+  val empty = Reliefs(None)
+
   implicit val writes: OWrites[Reliefs] = Json.writes[Reliefs]
 
   implicit val reads: Reads[Reliefs] =

--- a/app/v1/models/response/getCalculation/allowancesAndDeductions/summary/CalculationSummary.scala
+++ b/app/v1/models/response/getCalculation/allowancesAndDeductions/summary/CalculationSummary.scala
@@ -23,6 +23,8 @@ import utils.NestedJsonReads
 case class CalculationSummary(totalAllowancesAndDeductions: Option[BigInt], totalReliefs: Option[BigInt])
 
 object CalculationSummary extends NestedJsonReads{
+  val empty = CalculationSummary(None, None)
+
   implicit val writes: Writes[CalculationSummary] = Json.writes[CalculationSummary]
   implicit val reads: Reads[CalculationSummary] = (
     (JsPath \ "calculation" \ "taxCalculation" \ "incomeTax" \ "totalAllowancesAndDeductions").readNestedNullable[BigInt] and

--- a/app/v1/models/response/getCalculation/endOfYearEstimate/EoyEstimate.scala
+++ b/app/v1/models/response/getCalculation/endOfYearEstimate/EoyEstimate.scala
@@ -21,8 +21,8 @@ import play.api.libs.json.{ JsPath, Json, OWrites, Reads }
 import v1.models.response.getCalculation.endOfYearEstimate.detail.EoyEstimateDetail
 import v1.models.response.getCalculation.endOfYearEstimate.summary.EoyEstimateSummary
 
-case class EoyEstimate(summary: EoyEstimateSummary = EoyEstimateSummary.emptyEoyEstimateSummary,
-                       detail: EoyEstimateDetail = EoyEstimateDetail.emptyEoyEstimateDetail)
+case class EoyEstimate(summary: EoyEstimateSummary = EoyEstimateSummary.empty,
+                       detail: EoyEstimateDetail = EoyEstimateDetail.empty)
 
 object EoyEstimate {
   implicit val writes: OWrites[EoyEstimate] = Json.writes[EoyEstimate]

--- a/app/v1/models/response/getCalculation/endOfYearEstimate/detail/EoyEstimateDetail.scala
+++ b/app/v1/models/response/getCalculation/endOfYearEstimate/detail/EoyEstimateDetail.scala
@@ -20,26 +20,22 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{ JsPath, Json, OWrites, Reads }
 import utils.NestedJsonReads
 
-case class EoyEstimateDetail(selfEmployments: Option[Seq[EoyEstimateSelfEmployment]] = None,
-                             ukPropertyFhl: Option[EoyEstimateUkPropertyFhl] = None,
-                             ukPropertyNonFhl: Option[EoyEstimateUkPropertyNonFhl] = None,
-                             ukSavings: Option[Seq[EoyEstimateUkSaving]] = None,
-                             ukDividends: Option[EoyEstimateUkDividends] = None) {
-
-  val isEmpty: Boolean = this == EoyEstimateDetail.emptyEoyEstimateDetail
-
-}
+case class EoyEstimateDetail(selfEmployments: Option[Seq[EoyEstimateSelfEmployment]],
+                             ukPropertyFhl: Option[EoyEstimateUkPropertyFhl],
+                             ukPropertyNonFhl: Option[EoyEstimateUkPropertyNonFhl],
+                             ukSavings: Option[Seq[EoyEstimateUkSaving]],
+                             ukDividends: Option[EoyEstimateUkDividends])
 
 object EoyEstimateDetail extends NestedJsonReads {
 
-  val emptyEoyEstimateDetail: EoyEstimateDetail = EoyEstimateDetail()
+  val empty = EoyEstimateDetail(None, None, None, None, None)
 
   implicit val writes: OWrites[EoyEstimateDetail] = Json.format[EoyEstimateDetail]
   implicit val reads: Reads[EoyEstimateDetail] = (
-    (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateSelfEmployment]("incomeSourceType", "01")).map(emptySeqToNone) and
-      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkPropertyFhl]("incomeSourceType", "04")).map(emptySeqToNone(_).getOrElse(Seq.empty).headOption) and
-      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkPropertyNonFhl]("incomeSourceType", "02")).map(emptySeqToNone(_).getOrElse(Seq.empty).headOption) and
-      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkSaving]("incomeSourceType", "09")).map(emptySeqToNone) and
-      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkDividends]("incomeSourceType", "10")).map(emptySeqToNone(_).getOrElse(Seq.empty).headOption)
+    (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateSelfEmployment]("incomeSourceType", "01")).mapEmptySeqToNone and
+      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkPropertyFhl]("incomeSourceType", "04")).mapHeadOption and
+      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkPropertyNonFhl]("incomeSourceType", "02")).mapHeadOption and
+      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkSaving]("incomeSourceType", "09")).mapEmptySeqToNone and
+      (JsPath \ "incomeSource").readNullable(filteredArrayReads[EoyEstimateUkDividends]("incomeSourceType", "10")).mapHeadOption
   )(EoyEstimateDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/endOfYearEstimate/summary/EoyEstimateSummary.scala
+++ b/app/v1/models/response/getCalculation/endOfYearEstimate/summary/EoyEstimateSummary.scala
@@ -18,19 +18,16 @@ package v1.models.response.getCalculation.endOfYearEstimate.summary
 
 import play.api.libs.json.{ Json, OFormat }
 
-case class EoyEstimateSummary(totalEstimatedIncome: Option[BigInt] = None,
-                              totalTaxableIncome: Option[BigInt] = None,
-                              incomeTaxAmount: Option[BigDecimal] = None,
-                              nic2: Option[BigDecimal] = None,
-                              nic4: Option[BigDecimal] = None,
-                              totalNicAmount: Option[BigDecimal] = None,
-                              incomeTaxNicAmount: Option[BigDecimal] = None){
-
-  val isEmpty: Boolean = this == EoyEstimateSummary.emptyEoyEstimateSummary
-
-}
+case class EoyEstimateSummary(totalEstimatedIncome: Option[BigInt],
+                              totalTaxableIncome: Option[BigInt],
+                              incomeTaxAmount: Option[BigDecimal],
+                              nic2: Option[BigDecimal],
+                              nic4: Option[BigDecimal],
+                              totalNicAmount: Option[BigDecimal],
+                              incomeTaxNicAmount: Option[BigDecimal])
 
 object EoyEstimateSummary {
-  val emptyEoyEstimateSummary: EoyEstimateSummary = EoyEstimateSummary()
+  val empty = EoyEstimateSummary(None, None, None, None, None, None, None)
+
   implicit val formats: OFormat[EoyEstimateSummary] = Json.format[EoyEstimateSummary]
 }

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/CalculationDetail.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/CalculationDetail.scala
@@ -28,16 +28,12 @@ object CalculationDetail extends NestedJsonReads {
   implicit val reads: Reads[CalculationDetail] = (
     (JsPath \ "calculation").read[IncomeTaxDetail] and
       (JsPath \ "calculation" \ "taxCalculation" \ "nics").readNestedNullable[NicDetail].map {
-        _.flatMap {
-          case NicDetail(None, None) => None
-          case other => Some(other)
-        }
+        case Some(NicDetail.empty) => None
+        case other => other
       } and
       (JsPath \ "calculation" \ "taxDeductedAtSource").readNestedNullable[TaxDeductedAtSource].map {
-        _.flatMap {
-          case TaxDeductedAtSource(None, None) => None
-          case other => Some(other)
-        }
+        case Some(TaxDeductedAtSource.empty) => None
+        case other => other
       }
   )(CalculationDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4Losses.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4Losses.scala
@@ -18,12 +18,11 @@ package v1.models.response.getCalculation.incomeTaxAndNics.detail
 
 import play.api.libs.json.{Json, OFormat}
 
-case class Class4Losses(totalClass4LossesAvailable: Option[BigInt], totalClass4LossesUsed: Option[BigInt]){
-  val isEmpty: Boolean = this == Class4Losses.emptyClass4Losses
-}
+case class Class4Losses(totalClass4LossesAvailable: Option[BigInt], totalClass4LossesUsed: Option[BigInt])
 
 object Class4Losses {
-  val emptyClass4Losses: Class4Losses = Class4Losses(None,None)
+  val empty = Class4Losses(None, None)
+
   implicit val formats: OFormat[Class4Losses] = Json.format[Class4Losses]
 }
 

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4NicDetail.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4NicDetail.scala
@@ -16,27 +16,26 @@
 
 package v1.models.response.getCalculation.incomeTaxAndNics.detail
 
-import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 import play.api.libs.functional.syntax._
-import v1.models.response.getCalculation.endOfYearEstimate.detail.EoyEstimateDetail.emptySeqToNone
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+import utils.NestedJsonReads
 
 case class Class4NicDetail(class4Losses: Option[Class4Losses],
                            totalIncomeLiableToClass4Charge: Option[BigInt],
                            totalIncomeChargeableToClass4: Option[BigInt],
-                           class4NicBands: Option[Seq[NicBand]]){
-  val isEmpty: Boolean = this == Class4NicDetail.emptyClass4NicDetail
-}
+                           class4NicBands: Option[Seq[NicBand]])
 
-object Class4NicDetail{
-  val emptyClass4NicDetail: Class4NicDetail = Class4NicDetail(None, None, None, None)
+object Class4NicDetail extends NestedJsonReads {
+  val empty = Class4NicDetail(None, None, None, None)
+
   implicit val writes: OWrites[Class4NicDetail] = Json.writes[Class4NicDetail]
   implicit val reads: Reads[Class4NicDetail] = (
     JsPath.readNullable[Class4Losses].map{
-      case Some(Class4Losses.emptyClass4Losses) => None
-      case notEmpty => notEmpty
+      case Some(Class4Losses.empty) => None
+      case other => other
     } and
       (JsPath \ "totalIncomeLiableToClass4Charge").readNullable[BigInt] and
       (JsPath \ "totalIncomeChargeableToClass4").readNullable[BigInt] and
-      (JsPath \ "nic4Bands").readNullable[Seq[NicBand]].map(emptySeqToNone)
+      (JsPath \ "nic4Bands").readNullable[Seq[NicBand]].mapEmptySeqToNone
     )(Class4NicDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/IncomeTaxDetail.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/IncomeTaxDetail.scala
@@ -26,6 +26,8 @@ case class IncomeTaxDetail(payPensionsProfit: Option[IncomeTypeBreakdown],
                            giftAid: Option[GiftAid])
 
 object IncomeTaxDetail extends NestedJsonReads {
+  val empty = IncomeTaxDetail(None, None, None, None)
+
   implicit val writes: OWrites[IncomeTaxDetail] = Json.writes[IncomeTaxDetail]
 
   implicit val reads: Reads[IncomeTaxDetail] = (

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/NicDetail.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/NicDetail.scala
@@ -23,13 +23,15 @@ import utils.NestedJsonReads
 case class NicDetail(class2Nics: Option[Class2NicDetail], class4Nics: Option[Class4NicDetail])
 
 object NicDetail extends NestedJsonReads{
+  val empty = NicDetail(None, None)
+
   implicit val writes: OWrites[NicDetail] = Json.writes[NicDetail]
 
   implicit val reads: Reads[NicDetail] = (
     (JsPath \ "class2Nics").readNullable[Class2NicDetail] and
-      (JsPath \ "class4Nics").readNullable[Class4NicDetail].map{
-        case Some(Class4NicDetail.emptyClass4NicDetail) => None
-        case notEmpty => notEmpty
+      (JsPath \ "class4Nics").readNullable[Class4NicDetail].map {
+        case Some(Class4NicDetail.empty) => None
+        case other => other
       }
   )(NicDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/TaxDeductedAtSource.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/detail/TaxDeductedAtSource.scala
@@ -23,6 +23,8 @@ case class TaxDeductedAtSource(ukLandAndProperty: Option[BigDecimal],
                                savings: Option[BigDecimal])
 
 object TaxDeductedAtSource {
+  val empty = TaxDeductedAtSource(None, None)
+
   implicit val writes: OWrites[TaxDeductedAtSource] = Json.writes[TaxDeductedAtSource]
 
   implicit val reads: Reads[TaxDeductedAtSource] = (

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/summary/CalculationSummary.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/summary/CalculationSummary.scala
@@ -32,11 +32,9 @@ object CalculationSummary extends NestedJsonReads {
 
   implicit val reads: Reads[CalculationSummary] = (
     (JsPath \ "calculation" \ "taxCalculation" \ "incomeTax").read[IncomeTaxSummary] and
-      (JsPath \ "calculation" \ "taxCalculation" \ "nics").readNestedNullable[NicSummary] .map {
-        _.flatMap {
-          case NicSummary(None, None, None) => None
-          case other => Some(other)
-        }
+      (JsPath \ "calculation" \ "taxCalculation" \ "nics").readNestedNullable[NicSummary].map {
+        case Some(NicSummary.empty) => None
+        case other => other
       } and
       (JsPath \ "calculation" \ "taxCalculation" \ "totalIncomeTaxNicsCharged").readNestedNullable[BigDecimal] and
       (JsPath \ "calculation" \ "taxCalculation" \ "totalTaxDeducted").readNestedNullable[BigDecimal] and

--- a/app/v1/models/response/getCalculation/incomeTaxAndNics/summary/NicSummary.scala
+++ b/app/v1/models/response/getCalculation/incomeTaxAndNics/summary/NicSummary.scala
@@ -23,6 +23,8 @@ import utils.NestedJsonReads
 case class NicSummary(class2NicsAmount: Option[BigDecimal], class4NicsAmount: Option[BigDecimal], totalNic: Option[BigDecimal])
 
 object NicSummary extends NestedJsonReads {
+  val empty = NicSummary(None, None ,None)
+
   implicit val writes: OWrites[NicSummary] = Json.writes[NicSummary]
 
   implicit val reads: Reads[NicSummary] = (

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/BusinessProfitAndLoss.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/BusinessProfitAndLoss.scala
@@ -29,22 +29,23 @@ case class BusinessProfitAndLoss(selfEmployments: Option[Seq[SelfEmployment]],
                                  ukPropertyNonFhl: Option[UkPropertyNonFhl])
 
 object BusinessProfitAndLoss extends NestedJsonReads {
-  implicit val writes: Writes[BusinessProfitAndLoss] = Json.writes[BusinessProfitAndLoss]
+  val empty = BusinessProfitAndLoss(None, None, None)
 
+  implicit val writes: Writes[BusinessProfitAndLoss] = Json.writes[BusinessProfitAndLoss]
 
   implicit val reads: Reads[BusinessProfitAndLoss] = (
     __.readNullable[Seq[SelfEmployment]](SelfEmployment.seqReads).map(_.flatMap {
       case Nil => None
       case x => Some(x)
     }) and
-    __.readNullable[UkPropertyFhl].map(_.flatMap {
-        case UkPropertyFhl(None, None, None, None, None, None, None, None, None, None, None, None) => None
-        case x => Some(x)
-      }) and
-      __.readNullable[UkPropertyNonFhl].map(_.flatMap {
-        case UkPropertyNonFhl(None, None, None, None, None, None, None, None, None, None, None, None) => None
-        case x => Some(x)
-      })
+      __.readNullable[UkPropertyFhl].map {
+        case Some(UkPropertyFhl.empty) => None
+        case other => other
+      } and
+      __.readNullable[UkPropertyNonFhl].map {
+        case Some(UkPropertyNonFhl.empty) => None
+        case other => other
+      }
     )(BusinessProfitAndLoss.apply _)
 
 }

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/CalculationDetail.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/CalculationDetail.scala
@@ -23,6 +23,8 @@ import utils.NestedJsonReads
 case class CalculationDetail(payPensionsProfit: Option[PayPensionsProfit], savingsAndGains: Option[SavingsAndGains], dividends: Option[Dividends])
 
 object CalculationDetail extends NestedJsonReads {
+  val empty = CalculationDetail(None, None, None)
+
   implicit val writes: OWrites[CalculationDetail] = Json.writes[CalculationDetail]
   implicit val reads: Reads[CalculationDetail] = (
     emptyIfNotPresent[PayPensionsProfit](__ \ "calculation" \ "taxCalculation" \ "incomeTax" \ "payPensionsProfit") and

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/PayPensionsProfit.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/PayPensionsProfit.scala
@@ -37,9 +37,9 @@ object PayPensionsProfit extends NestedJsonReads{
       (JsPath \ "calculation" \ "incomeSummaryTotals" \ "totalPropertyProfit").readNestedNullable[BigInt] and
       (JsPath \ "calculation" \ "incomeSummaryTotals" \ "totalFHLPropertyProfit").readNestedNullable[BigInt] and
       (JsPath \ "calculation" \ "incomeSummaryTotals" \ "totalUKOtherPropertyProfit").readNestedNullable[BigInt] and
-      __.readNullable[BusinessProfitAndLoss].map(_.flatMap {
-        case BusinessProfitAndLoss(None,None,None) => None
-        case x => Some(x)
-      })
+      __.readNullable[BusinessProfitAndLoss].map {
+        case Some(BusinessProfitAndLoss.empty) => None
+        case other => other
+      }
   )(PayPensionsProfit.apply _)
 }

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/detail/LossClaimsDetail.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/detail/LossClaimsDetail.scala
@@ -26,8 +26,6 @@ case class LossClaimsDetail(lossesBroughtForward: Option[Seq[LossBroughtForward]
                             carriedForwardLosses: Option[Seq[CarriedForwardLoss]],
                             claimsNotApplied: Option[Seq[ClaimNotApplied]]) {
 
-  val isEmpty: Boolean = this == LossClaimsDetail.emptyLossClaimsDetail
-
   def filterById(id: String): Option[LossClaimsDetail] = {
 
     val lossesBroughtForward  = this.lossesBroughtForward.getOrElse(Seq.empty).filter(lbf => lbf.incomeSourceId == id)
@@ -44,21 +42,21 @@ case class LossClaimsDetail(lossesBroughtForward: Option[Seq[LossBroughtForward]
       LossClaimsDetail.toNoneIfEmpty(claimsNotApplied)
     )
 
-    if (filteredDetail.isEmpty) None else Some(filteredDetail)
+    if (filteredDetail == LossClaimsDetail.empty) None else Some(filteredDetail)
   }
 
 }
 
 object LossClaimsDetail extends NestedJsonReads {
-  val emptyLossClaimsDetail: LossClaimsDetail = LossClaimsDetail(None, None, None, None, None)
+  val empty = LossClaimsDetail(None, None, None, None, None)
 
   def toNoneIfEmpty[A](seq: Seq[A]): Option[Seq[A]] = if (seq.nonEmpty) Some(seq) else None
 
   implicit val writes: OWrites[LossClaimsDetail] = Json.writes[LossClaimsDetail]
 
-  implicit val reads: Reads[LossClaimsDetail] = ((JsPath \ "inputs" \ "lossesBroughtForward").readNestedNullable(filteredArrayReads[LossBroughtForward]("incomeSourceType", "01")).map(emptySeqToNone) and
-    (JsPath \ "calculation" \ "lossesAndClaims" \ "resultOfClaimsApplied").readNestedNullable(filteredArrayReads[ResultOfClaimApplied]("incomeSourceType", "01")).map(emptySeqToNone) and
-    (JsPath \ "calculation" \ "lossesAndClaims" \ "unclaimedLosses").readNestedNullable(filteredArrayReads[UnclaimedLoss]("incomeSourceType", "01")).map(emptySeqToNone) and
-    (JsPath \ "calculation" \ "lossesAndClaims" \ "carriedForwardLosses").readNestedNullable(filteredArrayReads[CarriedForwardLoss]("incomeSourceType", "01")).map(emptySeqToNone) and
-    (JsPath \ "calculation" \ "lossesAndClaims" \ "claimsNotApplied").readNestedNullable(filteredArrayReads[ClaimNotApplied]("incomeSourceType", "01")).map(emptySeqToNone))(LossClaimsDetail.apply _)
+  implicit val reads: Reads[LossClaimsDetail] = ((JsPath \ "inputs" \ "lossesBroughtForward").readNestedNullable(filteredArrayReads[LossBroughtForward]("incomeSourceType", "01")).mapEmptySeqToNone and
+    (JsPath \ "calculation" \ "lossesAndClaims" \ "resultOfClaimsApplied").readNestedNullable(filteredArrayReads[ResultOfClaimApplied]("incomeSourceType", "01")).mapEmptySeqToNone and
+    (JsPath \ "calculation" \ "lossesAndClaims" \ "unclaimedLosses").readNestedNullable(filteredArrayReads[UnclaimedLoss]("incomeSourceType", "01")).mapEmptySeqToNone and
+    (JsPath \ "calculation" \ "lossesAndClaims" \ "carriedForwardLosses").readNestedNullable(filteredArrayReads[CarriedForwardLoss]("incomeSourceType", "01")).mapEmptySeqToNone and
+    (JsPath \ "calculation" \ "lossesAndClaims" \ "claimsNotApplied").readNestedNullable(filteredArrayReads[ClaimNotApplied]("incomeSourceType", "01")).mapEmptySeqToNone)(LossClaimsDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/summary/LossClaimsSummary.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/summary/LossClaimsSummary.scala
@@ -25,15 +25,11 @@ case class LossClaimsSummary(totalBroughtForwardIncomeTaxLosses: Option[BigInt],
                              totalBroughtForwardClass4Losses: Option[BigInt],
                              broughtForwardClass4LossesUsed: Option[BigInt],
                              carrySidewaysClass4LossesUsed: Option[BigInt],
-                             totalClass4LossesCarriedForward: Option[BigInt]) {
-
-  val isEmpty: Boolean = this == LossClaimsSummary.emptyLossClaimsSummary
-
-}
+                             totalClass4LossesCarriedForward: Option[BigInt])
 
 object LossClaimsSummary {
 
-  val emptyLossClaimsSummary: LossClaimsSummary = LossClaimsSummary(None, None, None, None, None, None, None)
+  val empty = LossClaimsSummary(None, None, None, None, None, None, None)
 
   implicit val writes: OWrites[LossClaimsSummary] = Json.writes[LossClaimsSummary]
 

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/UkPropertyFhl.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/UkPropertyFhl.scala
@@ -38,6 +38,7 @@ case class UkPropertyFhl(totalIncome: Option[BigDecimal],
                         )
 
 object UkPropertyFhl extends NestedJsonReads{
+  val empty = UkPropertyFhl(None, None, None, None, None, None, None, None, None, None, None, None)
 
   case class TopLevelElements(incomeSourceType: String,
                               totalIncome: Option[BigDecimal],
@@ -94,10 +95,10 @@ object UkPropertyFhl extends NestedJsonReads{
   implicit val reads: Reads[UkPropertyFhl] = (
     (JsPath \ "calculation" \ "businessProfitAndLoss")
       .readNestedNullableOpt[TopLevelElements](filteredArrayValueReads(None, "incomeSourceType", "04")) and
-     __.readNullable[LossClaimsDetail].map(_.flatMap {
-       case LossClaimsDetail(None,None,None) => None
-       case x => Some(x)
-     })
+     __.readNullable[LossClaimsDetail].map{
+       case Some(LossClaimsDetail.empty) => None
+       case other => other
+     }
     )(UkPropertyFhl.readsApply _)
 
 

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/detail/LossClaimsDetail.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/detail/LossClaimsDetail.scala
@@ -26,15 +26,17 @@ case class LossClaimsDetail(
                              defaultCarriedForwardLosses: Option[Seq[DefaultCarriedForwardLoss]]
                            )
 
-object LossClaimsDetail extends NestedJsonReads{
+object LossClaimsDetail extends NestedJsonReads {
+  val empty = LossClaimsDetail(None, None, None)
+
   implicit val writes: OWrites[LossClaimsDetail] = Json.writes[LossClaimsDetail]
 
   implicit val reads: Reads[LossClaimsDetail] = (
     (JsPath \ "inputs" \ "lossesBroughtForward")
-      .readNestedNullable[Seq[LossBroughtForward]](filteredArrayReads("incomeSourceType", "04")).map(emptySeqToNone) and
+      .readNestedNullable[Seq[LossBroughtForward]](filteredArrayReads("incomeSourceType", "04")).mapEmptySeqToNone and
       (JsPath \ "calculation" \ "lossesAndClaims" \ "resultOfClaimsApplied").
-        readNestedNullable[Seq[ResultOfClaimApplied]](filteredArrayReads("incomeSourceType", "04")).map(emptySeqToNone) and
+        readNestedNullable[Seq[ResultOfClaimApplied]](filteredArrayReads("incomeSourceType", "04")).mapEmptySeqToNone and
       (JsPath \ "calculation" \ "lossesAndClaims" \ "defaultCarriedForwardLosses").
-        readNestedNullable[Seq[DefaultCarriedForwardLoss]](filteredArrayReads("incomeSourceType", "04")).map(emptySeqToNone)
+        readNestedNullable[Seq[DefaultCarriedForwardLoss]](filteredArrayReads("incomeSourceType", "04")).mapEmptySeqToNone
   )(LossClaimsDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/summary/LossClaimsSummary.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/summary/LossClaimsSummary.scala
@@ -27,6 +27,8 @@ case class LossClaimsSummary(
                             )
 
 object LossClaimsSummary {
+  val empty = LossClaimsSummary(None, None, None, None)
+
   implicit val writes: OWrites[LossClaimsSummary] = Json.writes[LossClaimsSummary]
 
   implicit val reads: Reads[LossClaimsSummary] = (

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/UkPropertyNonFhl.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/UkPropertyNonFhl.scala
@@ -36,6 +36,7 @@ case class UkPropertyNonFhl(totalIncome: Option[BigDecimal],
                             lossClaimsDetail: Option[LossClaimsDetail])
 
 object UkPropertyNonFhl extends NestedJsonReads {
+  val empty = UkPropertyNonFhl(None, None, None, None, None, None, None, None, None, None, None, None)
 
   case class TopLevelElements(totalIncome: Option[BigDecimal],
                                       totalExpenses: Option[BigDecimal],
@@ -79,7 +80,7 @@ object UkPropertyNonFhl extends NestedJsonReads {
     (JsPath \ "calculation" \ "businessProfitAndLoss")
       .readNestedNullableOpt[TopLevelElements](filteredArrayValueReads(None, "incomeSourceType", "02")) and
       JsPath.readNullable[LossClaimsDetail].map {
-        case Some(LossClaimsDetail(None, None, None, None)) => None
+        case Some(LossClaimsDetail.empty) => None
         case other => other
       }
   )(UkPropertyNonFhl.componentApply _)

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/detail/LossClaimsDetail.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/detail/LossClaimsDetail.scala
@@ -26,16 +26,18 @@ case class LossClaimsDetail(lossesBroughtForward: Option[Seq[LossBroughtForward]
                             claimsNotApplied: Option[Seq[ClaimNotApplied]])
 
 object LossClaimsDetail extends NestedJsonReads {
+  val empty = LossClaimsDetail(None, None, None, None)
+
   implicit val writes: OWrites[LossClaimsDetail] = Json.writes[LossClaimsDetail]
 
   implicit val reads: Reads[LossClaimsDetail] = (
     (JsPath \ "inputs" \ "lossesBroughtForward")
-      .readNestedNullable[Seq[LossBroughtForward]](filteredArrayReads("incomeSourceType", "02")).map(emptySeqToNone) and
+      .readNestedNullable[Seq[LossBroughtForward]](filteredArrayReads("incomeSourceType", "02")).mapEmptySeqToNone and
       (JsPath \ "calculation" \ "lossesAndClaims" \ "resultOfClaimsApplied")
-        .readNestedNullable[Seq[ResultOfClaimApplied]](filteredArrayReads("incomeSourceType", "02")).map(emptySeqToNone) and
+        .readNestedNullable[Seq[ResultOfClaimApplied]](filteredArrayReads("incomeSourceType", "02")).mapEmptySeqToNone and
       (JsPath \ "calculation" \ "lossesAndClaims" \ "defaultCarriedForwardLosses")
-        .readNestedNullable[Seq[DefaultCarriedForwardLoss]](filteredArrayReads("incomeSourceType", "02")).map(emptySeqToNone) and
+        .readNestedNullable[Seq[DefaultCarriedForwardLoss]](filteredArrayReads("incomeSourceType", "02")).mapEmptySeqToNone and
       (JsPath \ "calculation" \ "lossesAndClaims" \ "claimsNotApplied")
-        .readNestedNullable[Seq[ClaimNotApplied]](filteredArrayReads("incomeSourceType", "02")).map(emptySeqToNone)
+        .readNestedNullable[Seq[ClaimNotApplied]](filteredArrayReads("incomeSourceType", "02")).mapEmptySeqToNone
   )(LossClaimsDetail.apply _)
 }

--- a/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/summary/LossClaimsSummary.scala
+++ b/app/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/summary/LossClaimsSummary.scala
@@ -24,6 +24,8 @@ case class LossClaimsSummary(totalBroughtForwardIncomeTaxLosses: Option[BigInt],
                              totalIncomeTaxLossesCarriedForward: Option[BigInt])
 
 object LossClaimsSummary {
+  val empty = LossClaimsSummary(None, None, None)
+
   implicit val writes: OWrites[LossClaimsSummary] = Json.writes[LossClaimsSummary]
 
   implicit val reads: Reads[LossClaimsSummary] = (

--- a/test/utils/NestedJsonReadsSpec.scala
+++ b/test/utils/NestedJsonReadsSpec.scala
@@ -20,7 +20,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import support.UnitSpec
 
-class NestedJsonReadsSpec extends UnitSpec {
+class NestedJsonReadsSpec extends UnitSpec with NestedJsonReads {
 
   case class Foo(foo1: String, foo2: String)
 
@@ -122,6 +122,38 @@ class NestedJsonReadsSpec extends UnitSpec {
                        |""".stripMargin).validate[Bar] shouldBe a[JsError]
         }
       }
+    }
+  }
+
+  "mapEmptySeqToNone" must {
+    val reads = (__).readNullable[Seq[String]].mapEmptySeqToNone
+
+    "map non-empty sequence to Some(non-empty sequence)" in {
+      JsArray(Seq(JsString("value0"), JsString("value1"))).as(reads) shouldBe Some(Seq("value0", "value1"))
+    }
+
+    "map empty sequence to None" in {
+      JsArray.empty.as(reads) shouldBe None
+    }
+
+    "map None to None" in {
+      JsNull.as(reads) shouldBe None
+    }
+  }
+
+  "mapHeadOption" must {
+    val reads = (__).readNullable[Seq[String]].mapHeadOption
+
+    "map non-empty sequence to Some(1st element)" in {
+      JsArray(Seq(JsString("value0"), JsString("value1"))).as(reads) shouldBe Some("value0")
+    }
+
+    "map empty sequence to None" in {
+      JsArray.empty.as(reads) shouldBe None
+    }
+
+    "map None to None" in {
+      JsNull.as(reads) shouldBe None
     }
   }
 }

--- a/test/v1/fixtures/GetCalculationResponseFixtures.scala
+++ b/test/v1/fixtures/GetCalculationResponseFixtures.scala
@@ -25,13 +25,9 @@ object GetCalculationResponseFixtures {
     Some(AllowancesAndDeductions(Some(1000), Some(1000), Some(1000), Some(1000), Some(1000))),
     Some(Reliefs(Some(ResidentialFinanceCosts(1000, Some(1000), 2, 1000)))))
 
-  val adrCalculationDetailTemp = CalculationDetail(None,None)
-
   val adrCalculationSummary = CalculationSummary(Some(1000), Some(1000))
 
-  val adrCalculationSummaryTemp = CalculationSummary(None,None)
-
   val allowancesDeductionsAnsReliefs = AllowancesDeductionsAndReliefs(adrCalculationSummary, adrCalculationDetail)
-  val allowancesDeductionsAnsReliefsTemp = AllowancesDeductionsAndReliefs(adrCalculationSummaryTemp, adrCalculationDetailTemp)
+  val allowancesDeductionsAnsReliefsTemp = AllowancesDeductionsAndReliefs(CalculationSummary.empty, CalculationDetail.empty)
 
 }

--- a/test/v1/fixtures/endOfYearEstimate/detail/EoyEstimateDetailFixtures.scala
+++ b/test/v1/fixtures/endOfYearEstimate/detail/EoyEstimateDetailFixtures.scala
@@ -36,7 +36,10 @@ object EoyEstimateDetailFixtures {
 
   val eoyEstimateDetailResponseReduced: EoyEstimateDetail = EoyEstimateDetail(
     selfEmployments = Some(Seq(eoyEstimateSelfEmploymentResponse)),
-    ukSavings = Some(Seq(eoyEstimateUkSavingResponse, eoyEstimateUkSavingResponse))
+    ukPropertyFhl = None,
+    ukPropertyNonFhl = None,
+    ukSavings = Some(Seq(eoyEstimateUkSavingResponse, eoyEstimateUkSavingResponse)),
+    ukDividends = None
   )
 
   val eoyEstimateDetailDesJson: JsObject =

--- a/test/v1/fixtures/taxableIncome/detail/CalculationDetailFixtures.scala
+++ b/test/v1/fixtures/taxableIncome/detail/CalculationDetailFixtures.scala
@@ -70,7 +70,4 @@ object CalculationDetailFixtures {
   val detailWrittenJsonWithoutPPP: JsValue = dividendsJsonComponent.deepMerge(savingsAndGainsJsonComponent)
   val detailWrittenJsonWithoutSAG: JsValue = dividendsJsonComponent.deepMerge(payPensionsProfitJsonComponent)
   val detailWrittenJsonWithoutDiv: JsValue = savingsAndGainsJsonComponent.deepMerge(payPensionsProfitJsonComponent)
-
-  val emptyDetailResponse = CalculationDetail(None, None, None)
-
 }

--- a/test/v1/fixtures/taxableIncome/detail/ukPropertyFhl/UkPropertyFhlFixtures.scala
+++ b/test/v1/fixtures/taxableIncome/detail/ukPropertyFhl/UkPropertyFhlFixtures.scala
@@ -345,8 +345,6 @@ object UkPropertyFhlFixtures {
     Some(1000.00),Some(1000.00),None,Some(1000),Some(1000),
     Some(LossClaimsSummary(Some(1000),None,None,None)),None)
 
-  val emptyUkPropertyFhl = UkPropertyFhl(None, None, None, None, None, None, None, None, None, None, None, None)
-
   val mtdUkPropertyFhlObj: JsValue = Json.parse(
     """
       |{

--- a/test/v1/fixtures/taxableIncome/detail/ukPropertyNonFhl/LossClaimsDetailFixtures.scala
+++ b/test/v1/fixtures/taxableIncome/detail/ukPropertyNonFhl/LossClaimsDetailFixtures.scala
@@ -119,6 +119,4 @@ object LossClaimsDetailFixtures extends UnitSpec {
     Some(Seq(DefaultCarriedForwardLossFixtures.defaultCarriedForwardLossModel)),
     Some(Seq(ClaimNotAppliedFixtures.claimNotAppliedModel))
   )
-
-  val emptyLossClaimsDetailModel = LossClaimsDetail(None, None, None, None)
 }

--- a/test/v1/fixtures/taxableIncome/detail/ukPropertyNonFhl/UkPropertyNonFhlFixtures.scala
+++ b/test/v1/fixtures/taxableIncome/detail/ukPropertyNonFhl/UkPropertyNonFhlFixtures.scala
@@ -106,6 +106,4 @@ object UkPropertyNonFhlFixtures {
     Some(LossClaimsSummaryFixtures.lossClaimsSummaryModel),
     Some(LossClaimsDetailFixtures.lossClaimsDetailModel)
   )
-
-  val emptyUkPropertyNonFhlModel = UkPropertyNonFhl(None, None, None, None, None, None, None, None, None, None, None, None)
 }

--- a/test/v1/models/des/LossTypeSpec.scala
+++ b/test/v1/models/des/LossTypeSpec.scala
@@ -23,8 +23,6 @@ import v1.models.des.LossType._
 
 class LossTypeSpec  extends UnitSpec with EnumJsonSpecSupport {
 
-  val desJson: JsValue = Json.toJson("")
-
   testRoundTrip[LossType](
     ("income", INCOME),
     ("class4nics", CLASS4NICS))

--- a/test/v1/models/des/ReliefClaimedSpec.scala
+++ b/test/v1/models/des/ReliefClaimedSpec.scala
@@ -17,10 +17,18 @@
 package v1.models.des
 
 import support.UnitSpec
+import utils.enums.EnumJsonSpecSupport
 import v1.models.des.ReliefClaimed._
 import v1.models.domain.TypeOfClaim
 
-class ReliefClaimedSpec extends UnitSpec {
+class ReliefClaimedSpec extends UnitSpec with EnumJsonSpecSupport {
+
+  testRoundTrip[ReliefClaimed](
+    "CF"    -> `CF`,
+    "CSGI"    -> `CSGI`,
+    "CFCSGI" -> `CFCSGI`,
+    "CSFHL" -> `CSFHL`)
+
   "TypeOfClaim" when {
     "getting DES reliefClaimed" must {
       "work" in {

--- a/test/v1/models/domain/TypeOfClaimSpec.scala
+++ b/test/v1/models/domain/TypeOfClaimSpec.scala
@@ -17,18 +17,15 @@
 package v1.models.domain
 
 import support.UnitSpec
-import v1.models.des.ReliefClaimed
+import utils.enums.EnumJsonSpecSupport
 import v1.models.domain.TypeOfClaim._
 
-class TypeOfClaimSpec extends UnitSpec {
-  "TypeOfClaim" when {
-    "getting DES reliefClaimed" must {
-      "work" in {
-        `carry-forward`.toReliefClaimed shouldBe ReliefClaimed.`CF`
-        `carry-sideways`.toReliefClaimed shouldBe ReliefClaimed.`CSGI`
-        `carry-forward-to-carry-sideways`.toReliefClaimed shouldBe ReliefClaimed.`CFCSGI`
-        `carry-sideways-fhl`.toReliefClaimed shouldBe ReliefClaimed.`CSFHL`
-      }
-    }
-  }
+class TypeOfClaimSpec extends UnitSpec with EnumJsonSpecSupport {
+
+  testRoundTrip[TypeOfClaim](
+    "carry-forward"                   -> `carry-forward`,
+    "carry-sideways"                  -> `carry-sideways`,
+    "carry-forward-to-carry-sideways" -> `carry-forward-to-carry-sideways`,
+    "carry-sideways-fhl"              -> `carry-sideways-fhl`
+  )
 }

--- a/test/v1/models/response/common/MessagesSpec.scala
+++ b/test/v1/models/response/common/MessagesSpec.scala
@@ -122,7 +122,6 @@ class MessagesSpec extends UnitSpec {
 
   val messagesResponse = Messages(Some(Seq(info1,info2)), Some(Seq(warn1,warn2)), Some(Seq(err1,err2)))
   val messagesResponseWithoutErrors = Messages(Some(Seq(info1,info2)), Some(Seq(warn1,warn2)), None)
-  val emptyMessageResponse = Messages(None, None, None)
 
   "Messages" when {
     "read from a valid JSON" should {
@@ -156,34 +155,34 @@ class MessagesSpec extends UnitSpec {
     }
 
     "errors is present, but is empty" should {
-      "read the calculationErrorCount as None" in{
+      "read the calculationErrorCount as None" in {
         desJsonWithEmptyErrors.as[Messages] shouldBe messagesResponseWithoutErrors
       }
     }
 
     "messages are not present" should {
       "read the calculationErrorCount as None" in {
-        desJsonWithoutMessages.as[Messages] shouldBe emptyMessageResponse
+        desJsonWithoutMessages.as[Messages] shouldBe Messages.empty
       }
     }
   }
 
   "Message" when {
-    "read from valid JSON" should{
-      "return a JsSuccess" in{
+    "read from valid JSON" should {
+      "return a JsSuccess" in {
         validMessageJson.validate[Message] shouldBe a[JsSuccess[_]]
       }
-      "with the expected Message object" in{
+      "with the expected Message object" in {
         validMessageJson.as[Message] shouldBe err1
       }
     }
-    "read from invalid JSON" should{
-      "return a JsError" in{
+    "read from invalid JSON" should {
+      "return a JsError" in {
         invalidMessageJson.validate[Message] shouldBe a[JsError]
       }
     }
-    "written to JSON" should{
-      "return the expected JsObject" in{
+    "written to JSON" should {
+      "return the expected JsObject" in {
         Json.toJson(err1) shouldBe validMessageJson
       }
     }

--- a/test/v1/models/response/getCalculation/allowancesAndDeductions/detail/AllowancesAndDeductionsSpec.scala
+++ b/test/v1/models/response/getCalculation/allowancesAndDeductions/detail/AllowancesAndDeductionsSpec.scala
@@ -102,7 +102,7 @@ class AllowancesAndDeductionsSpec extends UnitSpec with JsonErrorValidators{
 
     "return an empty summary object" when {
       "json has no AllowancesAndDeductions details" in {
-        desJsonWithNoAllowancesAndDeductionsDetails.as[AllowancesAndDeductions] shouldBe AllowancesAndDeductions(None, None, None, None, None)
+        desJsonWithNoAllowancesAndDeductionsDetails.as[AllowancesAndDeductions] shouldBe AllowancesAndDeductions.empty
       }
     }
   }
@@ -116,7 +116,7 @@ class AllowancesAndDeductionsSpec extends UnitSpec with JsonErrorValidators{
 
     "return an empty json" when {
       "AllowancesAndDeductions object has no data" in {
-        Json.toJson(AllowancesAndDeductions(None, None, None, None, None)) shouldBe JsObject.empty
+        Json.toJson(AllowancesAndDeductions.empty) shouldBe JsObject.empty
       }
     }
   }

--- a/test/v1/models/response/getCalculation/allowancesAndDeductions/detail/CalculationDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/allowancesAndDeductions/detail/CalculationDetailSpec.scala
@@ -80,7 +80,7 @@ class CalculationDetailSpec extends UnitSpec with JsonErrorValidators {
       }
 
       "json has no fields" in {
-        JsObject.empty.as[CalculationDetail] shouldBe CalculationDetail(None,None)
+        JsObject.empty.as[CalculationDetail] shouldBe CalculationDetail.empty
       }
     }
   }

--- a/test/v1/models/response/getCalculation/allowancesAndDeductions/detail/ReliefsSpec.scala
+++ b/test/v1/models/response/getCalculation/allowancesAndDeductions/detail/ReliefsSpec.scala
@@ -76,7 +76,7 @@ class ReliefsSpec extends UnitSpec with JsonErrorValidators {
       }
 
       "json has no fields" in {
-        JsObject.empty.as[Reliefs] shouldBe Reliefs(None)
+        JsObject.empty.as[Reliefs] shouldBe Reliefs.empty
       }
     }
   }

--- a/test/v1/models/response/getCalculation/allowancesAndDeductions/summary/CalculationSummarySpec.scala
+++ b/test/v1/models/response/getCalculation/allowancesAndDeductions/summary/CalculationSummarySpec.scala
@@ -99,7 +99,7 @@ class CalculationSummarySpec extends UnitSpec with JsonErrorValidators {
 
     "return an empty json" when {
       "summary object has no data" in {
-        Json.toJson(CalculationSummary(None, None)) shouldBe JsObject.empty
+        Json.toJson(CalculationSummary.empty) shouldBe JsObject.empty
       }
     }
   }

--- a/test/v1/models/response/getCalculation/endOfYearEstimate/detail/EoyEstimateDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/endOfYearEstimate/detail/EoyEstimateDetailSpec.scala
@@ -40,13 +40,13 @@ class EoyEstimateDetailSpec extends UnitSpec {
 
     "read from Json with all missing optional fields" should {
       "return the expected EoyEstimateDetail object" in {
-        eoyEstimateDetailDesJsonAllMissingOptionals.as[EoyEstimateDetail] shouldBe EoyEstimateDetail.emptyEoyEstimateDetail
+        eoyEstimateDetailDesJsonAllMissingOptionals.as[EoyEstimateDetail] shouldBe EoyEstimateDetail.empty
       }
     }
 
     "read from empty Json" should {
       "return an empty EoyEstimateDetail object" in {
-        JsObject.empty.as[EoyEstimateDetail].isEmpty shouldBe true
+        JsObject.empty.as[EoyEstimateDetail] shouldBe EoyEstimateDetail.empty
       }
     }
 
@@ -58,7 +58,7 @@ class EoyEstimateDetailSpec extends UnitSpec {
 
     "read from Json where all objects have an invalid income source type" should {
       "return an empty EoyEstimateDetail object" in {
-        eoyEstimateDetailDesJsonAllWrongIncomeSourceTypes.as[EoyEstimateDetail].isEmpty shouldBe true
+        eoyEstimateDetailDesJsonAllWrongIncomeSourceTypes.as[EoyEstimateDetail] shouldBe EoyEstimateDetail.empty
       }
     }
 
@@ -82,7 +82,7 @@ class EoyEstimateDetailSpec extends UnitSpec {
 
     "written from an empty EoyEstimateDetail object" should {
       "return an empty JsObject" in {
-        Json.toJson(EoyEstimateDetail.emptyEoyEstimateDetail) shouldBe JsObject.empty
+        Json.toJson(EoyEstimateDetail.empty) shouldBe JsObject.empty
       }
     }
 

--- a/test/v1/models/response/getCalculation/endOfYearEstimate/summary/EoyEstimateSummarySpec.scala
+++ b/test/v1/models/response/getCalculation/endOfYearEstimate/summary/EoyEstimateSummarySpec.scala
@@ -41,7 +41,7 @@ class EoyEstimateSummarySpec extends UnitSpec {
 
     "read from empty Json" should {
       "return an empty EoyEstimateSummary object" in {
-        JsObject.empty.as[EoyEstimateSummary].isEmpty shouldBe true
+        JsObject.empty.as[EoyEstimateSummary] shouldBe EoyEstimateSummary.empty
       }
     }
 

--- a/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4LossesSpec.scala
+++ b/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4LossesSpec.scala
@@ -16,7 +16,7 @@
 
 package v1.models.response.getCalculation.incomeTaxAndNics.detail
 
-import play.api.libs.json.{JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsObject, JsSuccess, JsValue, Json}
 import support.UnitSpec
 
 class Class4LossesSpec extends UnitSpec {
@@ -35,7 +35,11 @@ class Class4LossesSpec extends UnitSpec {
     }
 
     "read correctly from json" in {
-      json.validate[Class4Losses] shouldBe JsSuccess(model)
+      json.as[Class4Losses] shouldBe model
+    }
+
+    "read empty json to an empty object" in {
+      JsObject.empty.as[Class4Losses] shouldBe Class4Losses.empty
     }
   }
 }

--- a/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4NicDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/Class4NicDetailSpec.scala
@@ -16,7 +16,7 @@
 
 package v1.models.response.getCalculation.incomeTaxAndNics.detail
 
-import play.api.libs.json.{JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsObject, JsSuccess, JsValue, Json}
 import support.UnitSpec
 
 class Class4NicDetailSpec extends UnitSpec {
@@ -75,7 +75,11 @@ class Class4NicDetailSpec extends UnitSpec {
     }
 
     "read correctly from json" in {
-      desJson.validate[Class4NicDetail] shouldBe JsSuccess(model)
+      desJson.as[Class4NicDetail] shouldBe model
+    }
+
+    "read empty json to an empty object" in {
+      JsObject.empty.as[Class4NicDetail] shouldBe Class4NicDetail.empty
     }
   }
 }

--- a/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/IncomeTaxDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/IncomeTaxDetailSpec.scala
@@ -87,7 +87,6 @@ class IncomeTaxDetailSpec extends UnitSpec{
 
   def incomeTypeBreakdown(input: BigDecimal): IncomeTypeBreakdown = IncomeTypeBreakdown(input + 0.25, input + 0.5, None)
 
-  val emptyModel = IncomeTaxDetail(None, None, None, None)
   val filledModel = detail.IncomeTaxDetail(Some(incomeTypeBreakdown(100)),
     Some(incomeTypeBreakdown(200)),
     Some(incomeTypeBreakdown(300)),
@@ -99,11 +98,11 @@ class IncomeTaxDetailSpec extends UnitSpec{
     "read correctly from Json" when {
 
       "provided with empty json" in {
-        emptyJson.validate[IncomeTaxDetail] shouldBe JsSuccess(emptyModel)
+        emptyJson.validate[IncomeTaxDetail] shouldBe JsSuccess(IncomeTaxDetail.empty)
       }
 
       "provided with json containing empty models" in {
-        emptyModelJson.validate[IncomeTaxDetail] shouldBe JsSuccess(emptyModel)
+        emptyModelJson.validate[IncomeTaxDetail] shouldBe JsSuccess(IncomeTaxDetail.empty)
       }
 
       "provided with filled json" in {
@@ -114,7 +113,7 @@ class IncomeTaxDetailSpec extends UnitSpec{
     "write to json correctly" when {
 
       "provided with an empty model" in {
-        Json.toJson(emptyModel) shouldBe emptyJson
+        Json.toJson(IncomeTaxDetail.empty) shouldBe emptyJson
       }
 
       "provided with a filled model" in {

--- a/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/NicDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/NicDetailSpec.scala
@@ -72,7 +72,6 @@ class NicDetailSpec extends UnitSpec {
       |}
     """.stripMargin)
 
-  val emptyModel = NicDetail(None, None)
   val filledModel = NicDetail(Some(class2), Some(class4))
 
   "NicDetail" should {
@@ -80,22 +79,22 @@ class NicDetailSpec extends UnitSpec {
     "read from json correctly" when {
 
       "provided with empty json" in {
-        emptyJson.validate[NicDetail] shouldBe JsSuccess(emptyModel)
+        emptyJson.as[NicDetail] shouldBe NicDetail.empty
       }
 
       "provided with empty models in the json" in {
-        inputJsonWithEmptyModels.validate[NicDetail] shouldBe JsSuccess(emptyModel)
+        inputJsonWithEmptyModels.as[NicDetail] shouldBe NicDetail.empty
       }
 
       "provided with filled json" in {
-        filledJson.validate[NicDetail] shouldBe JsSuccess(filledModel)
+        filledJson.as[NicDetail] shouldBe filledModel
       }
     }
 
     "write to json correctly" when {
 
       "provided with an empty model" in {
-        Json.toJson(emptyModel) shouldBe emptyJson
+        Json.toJson(NicDetail.empty) shouldBe emptyJson
       }
 
       "provided with a filled model" in {

--- a/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/TaxDeductedAtSourceSpec.scala
+++ b/test/v1/models/response/getCalculation/incomeTaxAndNics/detail/TaxDeductedAtSourceSpec.scala
@@ -16,7 +16,7 @@
 
 package v1.models.response.getCalculation.incomeTaxAndNics.detail
 
-import play.api.libs.json.{JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import support.UnitSpec
 
 class TaxDeductedAtSourceSpec extends UnitSpec {
@@ -42,7 +42,11 @@ class TaxDeductedAtSourceSpec extends UnitSpec {
   "TaxDeductedAtSource" should {
 
     "read correctly from json" in {
-      json.validate[TaxDeductedAtSource] shouldBe JsSuccess(model)
+      json.as[TaxDeductedAtSource] shouldBe model
+    }
+
+    "read empty json as empty objecty" in {
+      JsObject.empty.as[TaxDeductedAtSource] shouldBe TaxDeductedAtSource.empty
     }
 
     "write correctly to json" in {

--- a/test/v1/models/response/getCalculation/incomeTaxAndNics/summary/NicSummarySpec.scala
+++ b/test/v1/models/response/getCalculation/incomeTaxAndNics/summary/NicSummarySpec.scala
@@ -16,7 +16,7 @@
 
 package v1.models.response.getCalculation.incomeTaxAndNics.summary
 
-import play.api.libs.json.{JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 import support.UnitSpec
 
 class NicSummarySpec extends UnitSpec {
@@ -55,7 +55,6 @@ class NicSummarySpec extends UnitSpec {
 
   val emptyJson: JsValue = Json.obj()
 
-  val emptyModel = NicSummary(None, None, None)
   val filledModel = NicSummary(Some(100.25), Some(200.25), Some(300.25))
 
   "NicSummary" should {
@@ -63,22 +62,22 @@ class NicSummarySpec extends UnitSpec {
     "read correctly from json" when {
 
       "provided with empty json" in {
-        emptyJson.validate[NicSummary] shouldBe JsSuccess(emptyModel)
+        emptyJson.as[NicSummary] shouldBe NicSummary.empty
       }
 
       "provided with json with empty models" in {
-        emptyModelJson.validate[NicSummary] shouldBe JsSuccess(emptyModel)
+        emptyModelJson.as[NicSummary] shouldBe NicSummary.empty
       }
 
       "provided with filled json" in {
-        filledJson.validate[NicSummary] shouldBe JsSuccess(filledModel)
+        filledJson.as[NicSummary] shouldBe filledModel
       }
     }
 
     "write correctly to json" when {
 
       "provided with an empty model" in {
-        Json.toJson(emptyModel) shouldBe emptyJson
+        Json.toJson(NicSummary.empty) shouldBe emptyJson
       }
 
       "provided with a filled model" in {

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/CalculationDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/CalculationDetailSpec.scala
@@ -66,7 +66,7 @@ class CalculationDetailSpec extends UnitSpec {
         emptyJson.validate[CalculationDetail] shouldBe a[JsSuccess[_]]
       }
       "with the expected Detail object" in {
-        emptyJson.as[CalculationDetail] shouldBe emptyDetailResponse
+        emptyJson.as[CalculationDetail] shouldBe CalculationDetail.empty
       }
     }
 

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/detail/LossClaimsDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/detail/LossClaimsDetailSpec.scala
@@ -39,13 +39,13 @@ class LossClaimsDetailSpec extends UnitSpec {
 
     "read from Json with no provided field arrays" should {
       "return an empty LossClaimsDetail object" in {
-        lossClaimsDetailDesJsonFactory().as[LossClaimsDetail].isEmpty shouldBe true
+        lossClaimsDetailDesJsonFactory().as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
     }
 
     "read from empty Json" should {
       "return an empty LossClaimsDetail object" in {
-        emptyJson.as[LossClaimsDetail].isEmpty shouldBe true
+        emptyJson.as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
     }
 
@@ -57,7 +57,7 @@ class LossClaimsDetailSpec extends UnitSpec {
 
     "written to Json from an empty lossClaimsDetail object" should {
       "return an empty JsObject" in {
-        Json.toJson(LossClaimsDetail.emptyLossClaimsDetail) shouldBe emptyJson
+        Json.toJson(LossClaimsDetail.empty) shouldBe emptyJson
       }
     }
   }
@@ -66,8 +66,7 @@ class LossClaimsDetailSpec extends UnitSpec {
     "reading in a sequence of lossBroughtForward" must {
       "not include where incomeSourceType is not 01" in {
         lossClaimsDetailDesJsonFactory(lossesBroughtForward = Seq(lossBroughtForwardDesJsonWithWrongIncomeSourceType))
-          .as[LossClaimsDetail]
-          .isEmpty shouldBe true
+          .as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
       "include multiple matching items" in {
         val lossesBroughtForwardDes =
@@ -82,8 +81,7 @@ class LossClaimsDetailSpec extends UnitSpec {
     "reading in a sequence of resultOfClaimApplied" must {
       "not include where incomeSourceType is not 01" in {
         lossClaimsDetailDesJsonFactory(resultOfClaimsApplied = Seq(resultOfClaimAppliedDesJsonWithWrongIncomeSourceType))
-          .as[LossClaimsDetail]
-          .isEmpty shouldBe true
+          .as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
       "include multiple matching items" in {
         val resultOfClaimsAppliedDes =
@@ -98,8 +96,7 @@ class LossClaimsDetailSpec extends UnitSpec {
     "reading in a sequence of unclaimedLoss" must {
       "not include where incomeSourceType is not 01" in {
         lossClaimsDetailDesJsonFactory(unclaimedLosses = Seq(unclaimedLossDesJsonWithWrongIncomeSourceType))
-          .as[LossClaimsDetail]
-          .isEmpty shouldBe true
+          .as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
       "include multiple matching items" in {
         val unclaimedLossesDes =
@@ -114,8 +111,7 @@ class LossClaimsDetailSpec extends UnitSpec {
     "reading in a sequence of carriedForwardLoss" must {
       "not include where incomeSourceType is not 01" in {
         lossClaimsDetailDesJsonFactory(carriedForwardLosses = Seq(carriedForwardLossDesJsonWithWrongIncomeSourceType))
-          .as[LossClaimsDetail]
-          .isEmpty shouldBe true
+          .as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
       "include multiple matching items" in {
         val carriedForwardLossDes =
@@ -130,8 +126,7 @@ class LossClaimsDetailSpec extends UnitSpec {
     "reading in a sequence of claimNotApplied" must {
       "not include where incomeSourceType is not 01" in {
         lossClaimsDetailDesJsonFactory(claimsNotApplied = Seq(claimNotAppliedDesJsonWithWrongIncomeSourceType))
-          .as[LossClaimsDetail]
-          .isEmpty shouldBe true
+          .as[LossClaimsDetail] shouldBe LossClaimsDetail.empty
       }
       "include multiple matching items" in {
         val claimNotAppliedDes =

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/summary/LossClaimsSummarySpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/selfEmployment/summary/LossClaimsSummarySpec.scala
@@ -34,7 +34,7 @@ class LossClaimsSummarySpec extends UnitSpec {
 
     "read from empty Json" should {
       "return an empty LossClaimsSummary object" in {
-        emptyJson.as[LossClaimsSummary].isEmpty shouldBe true
+        emptyJson.as[LossClaimsSummary] shouldBe LossClaimsSummary.empty
       }
     }
 
@@ -52,7 +52,7 @@ class LossClaimsSummarySpec extends UnitSpec {
 
     "written from an empty LossClaimsSummary object" should {
       "return an empty JsObject" in {
-        Json.toJson(LossClaimsSummary.emptyLossClaimsSummary) shouldBe emptyJson
+        Json.toJson(LossClaimsSummary.empty) shouldBe emptyJson
       }
     }
   }

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/UkPropertyFhlSpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/UkPropertyFhlSpec.scala
@@ -47,7 +47,7 @@ class UkPropertyFhlSpec extends UnitSpec {
       }
 
       "return a empty json with empty UkPropertyFhl object" in {
-        Json.toJson(emptyUkPropertyFhl) shouldBe
+        Json.toJson(UkPropertyFhl.empty) shouldBe
           JsObject.empty
       }
     }

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/summary/LossClaimsSummarySpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyFhl/summary/LossClaimsSummarySpec.scala
@@ -25,9 +25,6 @@ class LossClaimsSummarySpec extends UnitSpec with JsonErrorValidators {
 
 
   "LossClaimSummary" when {
-
-    val emptyLossClaimSummary = LossClaimsSummary(None,None,None,None)
-
     "read from valid Json" should {
 
       testPropertyType[LossClaimsSummary](lossClaimSummaryDesJson)(
@@ -61,7 +58,7 @@ class LossClaimsSummarySpec extends UnitSpec with JsonErrorValidators {
 
     "read from empty Json" should {
       "return a JsSuccess" in {
-        emptyJson.as[LossClaimsSummary] shouldBe emptyLossClaimSummary
+        emptyJson.as[LossClaimsSummary] shouldBe LossClaimsSummary.empty
       }
       "with the expected LossClaimSummary object" in {
         lossClaimSummaryDesJson.as[LossClaimsSummary] shouldBe lossClaimsSummaryResponse
@@ -76,7 +73,7 @@ class LossClaimsSummarySpec extends UnitSpec with JsonErrorValidators {
 
     "written from empty JSON" should {
       "return an empty JsObject" in {
-        Json.toJson(emptyLossClaimSummary) shouldBe emptyJson
+        Json.toJson(LossClaimsSummary.empty) shouldBe emptyJson
       }
     }
   }

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/UkPropertyNonFhlSpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/UkPropertyNonFhlSpec.scala
@@ -35,19 +35,19 @@ class UkPropertyNonFhlSpec extends UnitSpec {
       "provided with valid json with all optional values and only invalid types" in {
         val result = UkPropertyNonFhlFixtures.ukPropertyNonFhlDesJsonWithoutValidTypes.validate[UkPropertyNonFhl]
         result shouldBe a[JsSuccess[_]]
-        result.get shouldBe UkPropertyNonFhlFixtures.emptyUkPropertyNonFhlModel
+        result.get shouldBe UkPropertyNonFhl.empty
       }
 
       "provided with valid json without optional values" in {
         val result = UkPropertyNonFhlFixtures.ukPropertyNonFhlDesJsonWithoutOptionals.validate[UkPropertyNonFhl]
         result shouldBe a[JsSuccess[_]]
-        result.get shouldBe UkPropertyNonFhlFixtures.emptyUkPropertyNonFhlModel
+        result.get shouldBe UkPropertyNonFhl.empty
       }
 
       "provided with empty json" in {
         val result = UkPropertyNonFhlFixtures.emptyJson.validate[UkPropertyNonFhl]
         result shouldBe a[JsSuccess[_]]
-        result.get shouldBe UkPropertyNonFhlFixtures.emptyUkPropertyNonFhlModel
+        result.get shouldBe UkPropertyNonFhl.empty
       }
     }
 
@@ -58,7 +58,7 @@ class UkPropertyNonFhlSpec extends UnitSpec {
       }
 
       "provided with a valid model with no optional values" in {
-        Json.toJson(UkPropertyNonFhlFixtures.emptyUkPropertyNonFhlModel) shouldBe UkPropertyNonFhlFixtures.emptyJson
+        Json.toJson(UkPropertyNonFhl.empty) shouldBe UkPropertyNonFhlFixtures.emptyJson
       }
     }
   }

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/detail/LossClaimsDetailSpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/detail/LossClaimsDetailSpec.scala
@@ -35,19 +35,19 @@ class LossClaimsDetailSpec extends UnitSpec {
       "provided with json with all optional values and only invalid income sources" in {
         val result = LossClaimsDetailFixtures.lossClaimsDetailDesJsonWithoutValidTypes.validate[LossClaimsDetail]
         result shouldBe a[JsSuccess[_]]
-        result.get shouldBe LossClaimsDetailFixtures.emptyLossClaimsDetailModel
+        result.get shouldBe LossClaimsDetail.empty
       }
 
       "provided with json without optional values" in {
         val result = LossClaimsDetailFixtures.lossClaimsDetailDesJsonWithoutOptionals.validate[LossClaimsDetail]
         result shouldBe a[JsSuccess[_]]
-        result.get shouldBe LossClaimsDetailFixtures.emptyLossClaimsDetailModel
+        result.get shouldBe LossClaimsDetail.empty
       }
 
       "provided with empty json" in {
         val result = LossClaimsDetailFixtures.emptyJson.validate[LossClaimsDetail]
         result shouldBe a[JsSuccess[_]]
-        result.get shouldBe LossClaimsDetailFixtures.emptyLossClaimsDetailModel
+        result.get shouldBe LossClaimsDetail.empty
       }
     }
 
@@ -58,7 +58,7 @@ class LossClaimsDetailSpec extends UnitSpec {
       }
 
       "provided with a model with no optional fields" in {
-        Json.toJson(LossClaimsDetailFixtures.emptyLossClaimsDetailModel) shouldBe LossClaimsDetailFixtures.emptyJson
+        Json.toJson(LossClaimsDetail.empty) shouldBe LossClaimsDetailFixtures.emptyJson
       }
     }
   }

--- a/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/summary/LossClaimsSummarySpec.scala
+++ b/test/v1/models/response/getCalculation/taxableIncome/detail/ukPropertyNonFhl/summary/LossClaimsSummarySpec.scala
@@ -26,8 +26,6 @@ class LossClaimsSummarySpec extends UnitSpec with JsonErrorValidators {
 
   "LossClaimSummary" when {
 
-    val emptyLossClaimSummary = LossClaimsSummary(None,None,None)
-
     "read from valid Json" should {
 
       testPropertyType[LossClaimsSummary](lossClaimSummaryDesJson)(
@@ -56,7 +54,7 @@ class LossClaimsSummarySpec extends UnitSpec with JsonErrorValidators {
 
     "read from empty Json" should {
       "return a JsSuccess" in {
-        JsObject.empty.as[LossClaimsSummary] shouldBe emptyLossClaimSummary
+        JsObject.empty.as[LossClaimsSummary] shouldBe LossClaimsSummary.empty
       }
       "with the expected LossClaimSummary object" in {
         lossClaimSummaryDesJson.as[LossClaimsSummary] shouldBe lossClaimsSummaryModel
@@ -71,7 +69,7 @@ class LossClaimsSummarySpec extends UnitSpec with JsonErrorValidators {
 
     "written from empty JSON" should {
       "return an empty JsObject" in {
-        Json.toJson(emptyLossClaimSummary) shouldBe JsObject.empty
+        Json.toJson(LossClaimsSummary.empty) shouldBe JsObject.empty
       }
     }
   }


### PR DESCRIPTION
- handle mapping optional empty case classes to None consistently
- changed emptySeqToNone to an extension method to avoid the extra explicity map boilerplate and added tests for this
- also added mapHeadOption extension method to clarify and avoid multiple operations when when getting headOption in a few places